### PR TITLE
(fix) rendering google maps on ios simulator needs https

### DIFF
--- a/arrowIonic/www/index.html
+++ b/arrowIonic/www/index.html
@@ -33,6 +33,6 @@
       have templates inline in this html file if you'd like).
     -->
     <ion-nav-view></ion-nav-view>
-    <script src="http://maps.google.com/maps/api/js?sensor=true"></script>
+    <script src="https://maps.google.com/maps/api/js?sensor=true"></script>
   </body>
 </html>


### PR DESCRIPTION
rendering google maps on ios simulator needs https
